### PR TITLE
Patch Unlootable Bug

### DIFF
--- a/ESOMinion/ai_gather.lua
+++ b/ESOMinion/ai_gather.lua
@@ -278,7 +278,8 @@ function c_Loot:evaluate()
 end
 function e_Loot:execute()
 	ml_log("e_Loot")
-	local CharList = EntityList("lootable,shortestpath,onmesh")
+	local blackliststring = ml_blacklist.GetExcludeString(GetString("monsters")) or ""
+	local CharList = EntityList("lootable,shortestpath,onmesh,exclude="..blackliststring)
 	if ( TableSize(CharList) > 0 ) then
 		local id,entity = next (CharList)
 		if ( id and entity ) then


### PR DESCRIPTION
Bug: Bot will try to loot a blacklisted lootable nonstop.
Reason: loot cause checks for the presence of lootable that is not
blacklisted while loot effect checks for the presence of all lootables
including blacklisted ones and will therefore try to loot it.
Fix: Filter out blacklisted lootables in loot effect function.
