### PR TITLE
Update ai_assist.lua

### DIFF
--- a/ESOMinion/ai_assist.lua
+++ b/ESOMinion/ai_assist.lua
@@ -22,7 +22,7 @@ end
 function eso_ai_assist:Process()
 	--ml_log("AssistMode_Process->")
 		
-	if ( ml_global_information.Player_Dead == false ) then
+	if ( ml_global_information.Player_Dead == false ) and ( e("IsMounted()") == false ) then
 		
 		
 		-- LootAll


### PR DESCRIPTION
Stop "Assist" mode from dismounting a player when they simply mouse over an enemy.